### PR TITLE
Fix/suppressoptionalwarnings

### DIFF
--- a/Hands-on lab/Lab-files/DeviceSimulation/Services/Runtime/ConfigData.cs
+++ b/Hands-on lab/Lab-files/DeviceSimulation/Services/Runtime/ConfigData.cs
@@ -220,8 +220,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime
                 // Remove placeholders
                 value = keys.Aggregate(value, (current, k) => current.Replace("${?" + k + "}", string.Empty));
 
-                var varsNotFound = keys.Aggregate(", ", (current, k) => current + k);
-                this.log.Warn("Environment variables not found", () => new { varsNotFound });
+                //suppress optional placeholder environment variable missing messages.
+                //var varsNotFound = keys.Aggregate(", ", (current, k) => current + k);
+                //this.log.Warn("Environment variables not found", () => new { varsNotFound });
 
                 notFound = true;
             }

--- a/Hands-on lab/Lab-files/DeviceSimulation/Services/Runtime/ConfigData.cs
+++ b/Hands-on lab/Lab-files/DeviceSimulation/Services/Runtime/ConfigData.cs
@@ -145,7 +145,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.Services.Runtime
             this.ReplaceEnvironmentVariables(ref value, defaultValue);
 
             if (value != notFound) return value;
-            this.log.Info("Configuration setting not found, using default value", () => new { key, defaultValue });
+            //suppress using default value messages
+            //this.log.Info("Configuration setting not found, using default value", () => new { key, defaultValue });
             return defaultValue;
         }
 

--- a/Hands-on lab/Lab-files/DeviceSimulation/Services/data/devicemodels/bus-01.json
+++ b/Hands-on lab/Lab-files/DeviceSimulation/Services/data/devicemodels/bus-01.json
@@ -4,7 +4,7 @@
   "Version": "0.0.1",
   "Name": "Bus",
   "Description": "Bus with GPS, speed, and fuel-level sensors",
-  "Protocol": "AMQP",
+  "Protocol": "MQTT",
   "Simulation": {
     /*
     "InitialState": {

--- a/Hands-on lab/Lab-files/DeviceSimulation/Services/data/devicemodels/bus-02.json
+++ b/Hands-on lab/Lab-files/DeviceSimulation/Services/data/devicemodels/bus-02.json
@@ -4,7 +4,7 @@
   "Version": "0.0.1",
   "Name": "Bus",
   "Description": "Bus with GPS, speed, and fuel-level sensors",
-  "Protocol": "AMQP",
+  "Protocol": "MQTT",
   "Simulation": {
     /*
     "InitialState": {

--- a/Hands-on lab/Lab-files/DeviceSimulation/WebService/Auth/AuthMiddleware.cs
+++ b/Hands-on lab/Lab-files/DeviceSimulation/WebService/Auth/AuthMiddleware.cs
@@ -69,13 +69,13 @@ namespace Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService.Auth
             this.diagnosticsLogger = diagnosticsLogger;
             this.authRequired = config.AuthRequired;
             this.tokenValidationInitialized = false;
-
+            this.authRequired = false;
             // This will show in development mode, or in case auth is turned off
             if (!this.authRequired)
             {
-                this.log.Warn("### AUTHENTICATION IS DISABLED! ###");
-                this.log.Warn("### AUTHENTICATION IS DISABLED! ###");
-                this.log.Warn("### AUTHENTICATION IS DISABLED! ###");
+                //this.log.Warn("### AUTHENTICATION IS DISABLED! ###");
+                //this.log.Warn("### AUTHENTICATION IS DISABLED! ###");
+                //this.log.Warn("### AUTHENTICATION IS DISABLED! ###");
             }
             else
             {


### PR DESCRIPTION
suppressing warning messages, change communication protocol from AMQP to MQTT (device twin was failing over AMQP for some reason).

Satisfies issue #42 - suppressing the warning messages to avoid confusion.