### PR TITLE
Moving IoT Edge module back to .NET Core 2.1

### DIFF
--- a/Hands-on lab/Lab-files/VehicleTelemetrySimulator/.vscode/launch.json
+++ b/Hands-on lab/Lab-files/VehicleTelemetrySimulator/.vscode/launch.json
@@ -28,7 +28,7 @@
       "name": "VehicleTelemetrySimulator Local Debug (.NET Core)",
       "type": "coreclr",
       "request": "launch",
-      "program": "${workspaceRoot}/modules/VehicleTelemetrySimulator/bin/Debug/netcoreapp2.2/VehicleTelemetrySimulator.dll",
+      "program": "${workspaceRoot}/modules/VehicleTelemetrySimulator/bin/Debug/netcoreapp2.1/VehicleTelemetrySimulator.dll",
       "args": [],
       "cwd": "${workspaceRoot}/modules/VehicleTelemetrySimulator",
       "internalConsoleOptions": "openOnSessionStart",

--- a/Hands-on lab/Lab-files/VehicleTelemetrySimulator/modules/VehicleTelemetrySimulator/Dockerfile.amd64
+++ b/Hands-on lab/Lab-files/VehicleTelemetrySimulator/modules/VehicleTelemetrySimulator/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-sdk AS build-env
+FROM microsoft/dotnet:2.1-sdk AS build-env
 WORKDIR /app
 
 COPY *.csproj ./
@@ -7,7 +7,7 @@ RUN dotnet restore
 COPY . ./
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.2-runtime
+FROM microsoft/dotnet:2.1-runtime
 WORKDIR /app
 COPY --from=build-env /app/out ./
 

--- a/Hands-on lab/Lab-files/VehicleTelemetrySimulator/modules/VehicleTelemetrySimulator/Dockerfile.amd64.debug
+++ b/Hands-on lab/Lab-files/VehicleTelemetrySimulator/modules/VehicleTelemetrySimulator/Dockerfile.amd64.debug
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-runtime-stretch AS base
+FROM microsoft/dotnet:2.1-runtime-stretch AS base
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends unzip procps && \
@@ -8,7 +8,7 @@ RUN useradd -ms /bin/bash moduleuser
 USER moduleuser
 RUN curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l ~/vsdbg
 
-FROM microsoft/dotnet:2.2-sdk AS build-env
+FROM microsoft/dotnet:2.1-sdk AS build-env
 WORKDIR /app
 
 COPY *.csproj ./

--- a/Hands-on lab/Lab-files/VehicleTelemetrySimulator/modules/VehicleTelemetrySimulator/Dockerfile.arm32v7
+++ b/Hands-on lab/Lab-files/VehicleTelemetrySimulator/modules/VehicleTelemetrySimulator/Dockerfile.arm32v7
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-sdk AS build-env
+FROM microsoft/dotnet:2.1-sdk AS build-env
 WORKDIR /app
 
 COPY *.csproj ./
@@ -7,7 +7,7 @@ RUN dotnet restore
 COPY . ./
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.2-runtime-stretch-slim-arm32v7
+FROM microsoft/dotnet:2.1-runtime-stretch-slim-arm32v7
 WORKDIR /app
 COPY --from=build-env /app/out ./
 

--- a/Hands-on lab/Lab-files/VehicleTelemetrySimulator/modules/VehicleTelemetrySimulator/Dockerfile.windows-amd64
+++ b/Hands-on lab/Lab-files/VehicleTelemetrySimulator/modules/VehicleTelemetrySimulator/Dockerfile.windows-amd64
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-sdk AS build-env
+FROM microsoft/dotnet:2.1-sdk AS build-env
 WORKDIR /app
 
 COPY *.csproj ./
@@ -7,7 +7,7 @@ RUN dotnet restore
 COPY . ./
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.2-runtime
+FROM microsoft/dotnet:2.1-runtime
 WORKDIR /app
 COPY --from=build-env /app/out ./
 ENTRYPOINT ["dotnet", "VehicleTelemetrySimulator.dll"]

--- a/Hands-on lab/Lab-files/VehicleTelemetrySimulator/modules/VehicleTelemetrySimulator/VehicleTelemetrySimulator.csproj
+++ b/Hands-on lab/Lab-files/VehicleTelemetrySimulator/modules/VehicleTelemetrySimulator/VehicleTelemetrySimulator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">


### PR DESCRIPTION
.NET Core 2.2 is not supported on Edge as of yet - was causing the VehicleTelemetry module to error silently and not deploy at all.