### PR TITLE
Set common .NET Core version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+package-lock.json
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/Hands-on lab/Before the HOL.md
+++ b/Hands-on lab/Before the HOL.md
@@ -63,9 +63,13 @@ Microsoft and the trademarks listed at <https://www.microsoft.com/en-us/legal/in
 
     - <https://docs.docker.com/engine/installation/>
 
-  - .NET Core 2.2 SDK
+  - .NET Core 2.1 SDK
+   
+    - <https://dotnet.microsoft.com/download/dotnet-core>
+  
+  - .NET Framework 4.6.1 Dev Pack
 
-    - <https://dotnet.microsoft.com/download>
+    - <https://dotnet.microsoft.com/download/dotnet-framework>
 
   - Visual Studio Community 2019 or greater, version 16.2.5 or higher
 

--- a/Hands-on lab/Lab-files/DeviceSimulation/PartitioningAgent.Test/PartitioningAgent.Test.csproj
+++ b/Hands-on lab/Lab-files/DeviceSimulation/PartitioningAgent.Test/PartitioningAgent.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
         <LangVersion>latest</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Hands-on lab/Lab-files/DeviceSimulation/PartitioningAgent/PartitioningAgent.csproj
+++ b/Hands-on lab/Lab-files/DeviceSimulation/PartitioningAgent/PartitioningAgent.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
         <AssemblyName>Microsoft.Azure.IoTSolutions.DeviceSimulation.PartitioningAgent</AssemblyName>
         <RootNamespace>Microsoft.Azure.IoTSolutions.DeviceSimulation.PartitioningAgent</RootNamespace>
         <LangVersion>latest</LangVersion>

--- a/Hands-on lab/Lab-files/DeviceSimulation/Services.Test/Services.Test.csproj
+++ b/Hands-on lab/Lab-files/DeviceSimulation/Services.Test/Services.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
         <LangVersion>latest</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Hands-on lab/Lab-files/DeviceSimulation/SimulationAgent.Test/SimulationAgent.Test.csproj
+++ b/Hands-on lab/Lab-files/DeviceSimulation/SimulationAgent.Test/SimulationAgent.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
         <LangVersion>latest</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Hands-on lab/Lab-files/DeviceSimulation/SimulationAgent/SimulationAgent.csproj
+++ b/Hands-on lab/Lab-files/DeviceSimulation/SimulationAgent/SimulationAgent.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent</AssemblyName>
     <RootNamespace>Microsoft.Azure.IoTSolutions.DeviceSimulation.SimulationAgent</RootNamespace>

--- a/Hands-on lab/Lab-files/DeviceSimulation/WebService.Test/WebService.Test.csproj
+++ b/Hands-on lab/Lab-files/DeviceSimulation/WebService.Test/WebService.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
         <LangVersion>latest</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Hands-on lab/Lab-files/DeviceSimulation/WebService/WebService.csproj
+++ b/Hands-on lab/Lab-files/DeviceSimulation/WebService/WebService.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
         <LangVersion>latest</LangVersion>
         <IsPackable>false</IsPackable>
         <AssemblyName>Microsoft.Azure.IoTSolutions.DeviceSimulation.WebService</AssemblyName>

--- a/Hands-on lab/Lab-files/LabVM/InstallVmSoftware.ps1
+++ b/Hands-on lab/Lab-files/LabVM/InstallVmSoftware.ps1
@@ -20,7 +20,7 @@ $Packages = 'googlechrome',`
             'visualstudio2019-workload-azure',`
             'visualstudio2019-workload-manageddesktop',`
             'visualstudio2019-workload-netweb',`
-            'dotnetcore-sdk'
+            'dotnetcore-sdk --version=2.1.805'            
 
 #Install Packages
 ForEach ($PackageName in $Packages)

--- a/Hands-on lab/Lab-files/StorageAdapter/Services.Test/Services.Test.csproj
+++ b/Hands-on lab/Lab-files/StorageAdapter/Services.Test/Services.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />

--- a/Hands-on lab/Lab-files/StorageAdapter/WebService.Test/WebService.Test.csproj
+++ b/Hands-on lab/Lab-files/StorageAdapter/WebService.Test/WebService.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="appsettings.ini">

--- a/Hands-on lab/Lab-files/StorageAdapter/WebService/WebService.csproj
+++ b/Hands-on lab/Lab-files/StorageAdapter/WebService/WebService.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7</LangVersion>
     <AssemblyName>Microsoft.Azure.IoTSolutions.StorageAdapter.WebService</AssemblyName>
     <RootNamespace>Microsoft.Azure.IoTSolutions.StorageAdapter.WebService</RootNamespace>


### PR DESCRIPTION
.NET Core 2.1 is the latest version supported on IoT Edge, downgraded all other projects to .NET Core 2.1 as well to keep only 1 version in the requirements. Also 2.2 was end of life and 2.1 is considered LTS. Fixes issue #52 